### PR TITLE
Fix packaged locale resources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ PLUGIN_ENTRY_POINT = f'{SKILL_NAME.lower()}.{SKILL_AUTHOR.lower()}={SKILL_PKG}:{
 
 
 def find_resource_files():
-    resource_base_dirs = ("locale")
+    resource_base_dirs = ("locale",)
     base_dir = path.dirname(__file__)
     package_data = ["*.json"]
     for res in resource_base_dirs:


### PR DESCRIPTION
The 0.1.10a2 wheel is missing the locale files, so `speak_dialog("unknown")` can fail at runtime.

`("locale")` is a string, not a tuple, so the package data walker never sees the locale directory.

Tested by building the wheel locally and checking that `locale/en-US/unknown.dialog` is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where locale and translation files were not being properly collected during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->