### PR TITLE
fix(ci): point release workflows at ovos_skill_fallback_unknown/version.py

### DIFF
--- a/.github/workflows/publish_stable.yml
+++ b/.github/workflows/publish_stable.yml
@@ -16,7 +16,7 @@ jobs:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
       MATRIX_TOKEN: ${{ secrets.MATRIX_TOKEN }}
     with:
-      version_file: 'version.py'
+      version_file: 'ovos_skill_fallback_unknown/version.py'
       publish_pypi: true
       publish_release: true
       sync_dev: true

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -11,4 +11,4 @@ jobs:
     secrets: inherit
     with:
       package_name: 'ovos_skill_fallback_unknown'
-      version_file: 'version.py'
+      version_file: 'ovos_skill_fallback_unknown/version.py'

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -19,7 +19,7 @@ jobs:
       MATRIX_TOKEN: ${{ secrets.MATRIX_TOKEN }}
     with:
       branch: 'dev'
-      version_file: 'version.py'
+      version_file: 'ovos_skill_fallback_unknown/version.py'
       update_changelog: true
       publish_prerelease: true
       propose_release: true


### PR DESCRIPTION
## Problem

PyPI is stuck at **0.1.10a2**, which still pins `ovos-workshop<9.0.0`. That cap is
the last test-dependency blocking `ovos-core` from resolving its modern
`ovos-workshop>=9.x` floor (the PIPELINE-1 / handler-lifecycle work). `dev` already
widened the cap to `<10.0.0` (#45), but the publish never happened.

Root cause: `release_workflow.yml` / `publish_stable.yml` / `release-preview.yml`
pass `version_file: 'version.py'`, but the file lives at
`ovos_skill_fallback_unknown/version.py`. publish-alpha's `bump_version` step fails
(exit 1) on every dev merge, so the bumped/changelogged version never reaches PyPI.

## Fix

Point all three workflows at `ovos_skill_fallback_unknown/version.py` — matching the
working sibling skills (e.g. `ovos-skill-hello-world`).

Once merged, the alpha publish lands a `0.1.x` with `ovos-workshop<10.0.0` and
ovos-core's ovoscope e2e closure resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)