### PR TITLE
fix: fallback-unknown picks longest voc match instead of fixed check order

### DIFF
--- a/ovos_skill_fallback_unknown/__init__.py
+++ b/ovos_skill_fallback_unknown/__init__.py
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import re
+
 from ovos_bus_client.message import Message
+from ovos_utils.text_utils import remove_accents_and_punct
 from ovos_workshop.skills.fallback import FallbackSkill
 from ovos_utils import classproperty
 from ovos_utils.process_utils import RuntimeRequirements
@@ -38,13 +41,47 @@ class UnknownSkill(FallbackSkill):
     def can_answer(self, message: Message) -> bool:
         return True
          
+    def _longest_voc_match(self, utterance, voc_filename):
+        """
+        Return the length of the longest vocab sample (normalized, accents
+        and punctuation stripped) from ``voc_filename`` that matches
+        ``utterance`` as a whole word/phrase, or -1 if none match.
+
+        voc_match() only tells us whether *any* sample matched, not which
+        one nor how long it was, so this replicates its exact matching
+        semantics (default exact=False -> whole-word substring containment,
+        see ovos_workshop.skills.ovos.OVOSSkill.voc_match) to let the caller
+        compare match specificity across multiple vocab classes.
+        """
+        try:
+            vocs = self.voc_list(voc_filename, self.lang)
+        except FileNotFoundError:
+            return -1
+        norm_utt = remove_accents_and_punct(utterance)
+        best = -1
+        for v in vocs:
+            norm_v = remove_accents_and_punct(v)
+            if re.match(r'.*\b' + re.escape(norm_v) + r'\b.*', norm_utt, re.IGNORECASE):
+                best = max(best, len(norm_v))
+        return best
+
     @fallback_handler(priority=100)
     def handle_fallback(self, message):
         utterance = message.data['utterance'].lower()
-        for i in ['question', 'who.is', 'why.is']:
-            if self.voc_match(utterance, i):
-                self.log.debug('Fallback type: ' + i)
-                self.speak_dialog(i)
-                break
+        # Evaluate all vocab classes and let the longest matched phrase win,
+        # so a narrower phrase (eg. gl-ES "que") doesn't shadow a longer,
+        # more specific phrase that contains it (eg. "por que será"). Ties
+        # are broken by the original fixed check order.
+        order = ['question', 'who.is', 'why.is']
+        best_type = None
+        best_len = -1
+        for i in order:
+            match_len = self._longest_voc_match(utterance, i)
+            if match_len > best_len:
+                best_len = match_len
+                best_type = i
+        if best_type is not None and best_len >= 0:
+            self.log.debug('Fallback type: ' + best_type)
+            self.speak_dialog(best_type)
         else:
             self.speak_dialog('unknown')

--- a/test/end2end/test_golden_utterances_multilang.py
+++ b/test/end2end/test_golden_utterances_multilang.py
@@ -135,30 +135,15 @@ def _golden_id(row):
     return f"{row['lang']}-{row['expected_dialog']}-{row['utterance']}"
 
 
-# Real routing defects reproduced by this pass, kept pinned rather than
-# silently dropped or weakened. Root cause (verified via
-# ovos_workshop.skills.fallback.FallbackSkill.voc_match source, default
-# exact=False): voc_match is a *substring* containment check, not a
-# whole-utterance match, and the skill's own handle_fallback checks
-# ['question', 'who.is', 'why.is'] in that fixed order (see
-# ovos_skill_fallback_unknown/__init__.py). In gl-ES and ro-RO, the
-# question.voc entries "que"/"ce este"/"ce va"/"ce a făcut" are legitimate,
-# narrower phrasings ("what is"/"what did") that also happen to be literal
-# substrings of the corresponding why.is.voc phrases ("por que
-# será"/"de ce este"/"de ce va"/"de ce a făcut" = "why will"/"why
-# is"/"why will"/"why did"), so "question" always wins the race before
-# "why.is" is even checked. This is not a vocab typo to trim: removing
-# those question.voc entries would delete real, narrower "what"-question
-# coverage those locales otherwise lack, and the fixed check order is
-# skill code, not locale content (out of scope for a locale-only pass).
-KNOWN_BUGS = {
-    ("gl-ES", "por que será"): "question.voc's bare 'que' entry is a substring of this why.is phrase and is checked first (fixed ['question','who.is','why.is'] order); see module comment above",
-    ("gl-ES", "por que é"): "same question.voc 'que' substring-precedence issue as 'por que será' above",
-    ("gl-ES", "por que fan"): "same question.voc 'que' substring-precedence issue as 'por que será' above",
-    ("ro-RO", "de ce va"): "question.voc's 'ce va' entry is a substring of this why.is phrase and is checked first (fixed ['question','who.is','why.is'] order); see module comment above",
-    ("ro-RO", "de ce a făcut"): "question.voc's 'ce a făcut' entry is a substring of this why.is phrase, same precedence issue as 'de ce va' above",
-    ("ro-RO", "de ce este"): "question.voc's 'ce este' entry is a substring of this why.is phrase, same precedence issue as 'de ce va' above",
-}
+# Regression pin for real routing defects previously reproduced by this
+# pass (gl-ES/ro-RO "que"/"ce este"/"ce va"/"ce a făcut" question.voc
+# entries being literal substrings of the corresponding why.is.voc
+# phrases). handle_fallback() now evaluates all three vocab classes and
+# picks the *longest* matched phrase instead of the first one checked in
+# fixed ['question', 'who.is', 'why.is'] order, so those rows pass outright
+# and no longer need an entry here. Kept as an empty, ready-to-use
+# mechanism for any future locale/order regression.
+KNOWN_BUGS = {}
 
 
 @pytest.mark.timeout(300)


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

## Summary
- `handle_fallback` checked `question`/`who.is`/`why.is` in a fixed order using substring `voc_match`, so a short `question.voc` entry (e.g. gl-ES "que", ro-RO "ce este") always won the race over a `why.is` phrase that legitimately contains it as a substring ("por que será", "de ce este"), even though the longer phrase is the more specific/correct match.
- Fix: evaluate all three vocab classes and pick the class whose matched vocab phrase is longest (normalized the same way `voc_match` normalizes); ties fall back to the original `['question', 'who.is', 'why.is']` order, so all currently-passing behavior is unchanged.
- Removed the now-fixed `KNOWN_BUGS` entries (gl-ES x3, ro-RO x3) from the multilang golden suite; the dict/xfail mechanism is kept in place, empty, for any future locale/order regression.

## Verification
- Confirmed red-before-fix: with the old handler, `pytest -k "gl-ES or ro-RO"` on the multilang suite gave `14 passed, 6 xfailed`.
- After the handler fix: same selection gives `20 passed, 0 xfailed`.
- Full local suite (`test/`, includes `test_fallback.py` + the 18-locale/168-row multilang golden suite + unit tests): `174 passed`, 0 failed, 0 xfailed, run twice for stability.

## Test plan
- [x] `pytest test/` green locally (174 passed)
- [x] 6 previously-xfailed gl-ES/ro-RO rows now pass
- [ ] CI green on this PR