### PR TITLE
fix: bare top-level pipe alternations in voc files never expanded

### DIFF
--- a/ovos_skill_fallback_unknown/locale/ca-ES/question.voc
+++ b/ovos_skill_fallback_unknown/locale/ca-ES/question.voc
@@ -1,13 +1,22 @@
 (on|en quin lloc)
 (on|en quin lloc) (va ser|van ser|fou|foren)
-en quin lloc|on
-on serà|on seran
-on serà|quan serà
-on és|on està|on són|on estan
+en quin lloc
+on
+on serà
+on seran
+quan serà
+on és
+on està
+on són
+on estan
 quan
 quan (va ser|van ser|fou|foren)
 quan és
 què fa
-què ha fet|què va fer
-què serà|què seran|què
-què és|què són
+què ha fet
+què va fer
+què serà
+què seran
+què
+què és
+què són

--- a/ovos_skill_fallback_unknown/locale/es-ES/question.voc
+++ b/ovos_skill_fallback_unknown/locale/es-ES/question.voc
@@ -1,9 +1,10 @@
 cuándo
-cuándo es|cuándo
+cuándo es
 dónde
-dónde está|dónde
-dónde lo hará|dónde
-qué es|qué
-qué hace|qué
-qué hará|qué
-qué hizo|qué
+dónde está
+dónde lo hará
+qué es
+qué
+qué hace
+qué hará
+qué hizo

--- a/ovos_skill_fallback_unknown/locale/es-ES/who.is.voc
+++ b/ovos_skill_fallback_unknown/locale/es-ES/who.is.voc
@@ -1,2 +1,2 @@
 quién
-quién es|quién
+quién es


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

## Bug

Found during adversarial review of #54 (pre-existing, not introduced by that PR). Some `ca-ES` and `es-ES` `.voc` lines use a bare top-level `|` alternation (e.g. `on|en quin lloc`, `cuándo es|cuándo`) instead of the parenthesized-group syntax `(a|b)`. `ovos-spec-tools`' `expand()` only splits parenthesized groups, so these lines load as a single literal string. After normalization (`remove_accents_and_punct`) the alternatives get concatenated into unmatchable garbage, e.g. `on serà|on seran` → `"on seraon seran"` instead of the two intended phrases `"on sera"` / `"on seran"`.

## Fix

Syntax-only: converted each bare top-level `|` alternation into separate `.voc` entries (one phrase per line), matching the prevailing style of full-entry alternatives elsewhere in these files. No word was added, removed, or translated — same set of alternatives, just correctly split so `expand()` actually expands them.

Files changed:
- `ovos_skill_fallback_unknown/locale/ca-ES/question.voc`
- `ovos_skill_fallback_unknown/locale/es-ES/question.voc`
- `ovos_skill_fallback_unknown/locale/es-ES/who.is.voc`

Swept **all** locales' `.voc` files for bare top-level `|` outside parentheses (script: walked each line tracking paren depth, flagged any `|` at depth 0). Only these two locales had the bug; every other locale (`cs-CZ`, `da-DK`, `de-DE`, `en-US`, `eu-ES`, `fa-IR`, `fr-FR`, `gl-ES`, `hu-HU`, `it-IT`, `nl-NL`, `pl-PL`, `pt-BR`, `pt-PT`, `ro-RO`, `ru-RU`, `sv-SE`) was clean.

## Verification

Used the real pipeline (`ovos_spec_tools.expand` + `ovos_utils.text_utils.remove_accents_and_punct`, the same one `ovos_workshop`'s vocab loader uses) to print normalized expansions of every affected file, before (checked out at `HEAD`, pre-fix) and after this change.

### `ca-ES/question.voc` (excerpt — only changed lines' expansions shown, unaffected lines identical before/after)

| Source line | Before (mangled) | After (correct) |
|---|---|---|
| `en quin lloc\|on` | `'en quin llocon'` | `'en quin lloc'`, `'on'` |
| `on serà\|on seran` | `'on seraon seran'` | `'on sera'`, `'on seran'` |
| `on serà\|quan serà` | `'on seraquan sera'` | `'on sera'`, `'quan sera'` |
| `on és\|on està\|on són\|on estan` | `'on eson estaon sonon estan'` | `'on es'`, `'on esta'`, `'on son'`, `'on estan'` |
| `què ha fet\|què va fer` | `'que ha fetque va fer'` | `'que ha fet'`, `'que va fer'` |
| `què serà\|què seran\|què` | `'que seraque seranque'` | `'que sera'`, `'que seran'`, `'que'` |
| `què és\|què són` | `'que esque son'` | `'que es'`, `'que son'` |

### `es-ES/question.voc`

| Source line | Before (mangled) | After (correct) |
|---|---|---|
| `cuándo es\|cuándo` | `'cuando escuando'` | `'cuando es'`, `'cuando'` |
| `dónde está\|dónde` | `'donde estadonde'` | `'donde esta'`, `'donde'` |
| `dónde lo hará\|dónde` | `'donde lo haradonde'` | `'donde lo hara'`, `'donde'` |
| `qué es\|qué` | `'que esque'` | `'que es'`, `'que'` |
| `qué hace\|qué` | `'que haceque'` | `'que hace'`, `'que'` |
| `qué hará\|qué` | `'que haraque'` | `'que hara'`, `'que'` |
| `qué hizo\|qué` | `'que hizoque'` | `'que hizo'`, `'que'` |

### `es-ES/who.is.voc`

| Source line | Before (mangled) | After (correct) |
|---|---|---|
| `quién es\|quién` | `'quien esquien'` | `'quien es'`, `'quien'` |

All other lines in these three files (the ones already using parenthesized-group syntax, e.g. `(on|en quin lloc)`) expand to the identical set before and after — confirmed line-by-line diff of the full expansion dump.

### Test suite

Fresh venv (`uv venv` + `uv pip install --pre -e .[test]`), full suite:

```
174 passed, 207 warnings in 17.01s
```

Matches the documented baseline of 174 passed. No golden-utterance class routing changed.

## Scope

Syntax fix only — no new words, no translation, no behavior change beyond making the existing intended alternatives actually match.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Expanded Catalan and Spanish fallback question recognition with clearer alternatives for location, time, and “what” queries.
  - Added standalone Spanish “qué” question matching.
  - Refined Spanish “who is” recognition to match the complete phrase more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->